### PR TITLE
Fix: improve mobile responsiveness across layout and components

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -58,17 +58,41 @@ NAV.forEach(item => {
   if (item.shortcut) SHORTCUT_MAP[item.shortcut.toLowerCase()] = item.to;
 });
 
+const MOBILE_BREAKPOINT = 900;
+
 export default function Layout() {
   const { user, logout, refreshUser } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [isSidebarVisible, setIsSidebarVisible] = useState(true);
+  const [isSidebarVisible, setIsSidebarVisible] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.innerWidth >= MOBILE_BREAKPOINT;
+  });
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < MOBILE_BREAKPOINT;
+  });
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
 
   // Refresh user data (streak, etc.) on every page navigation
   useEffect(() => {
     refreshUser().catch(() => {});
   }, [location.pathname]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const onResize = () => {
+      const nowMobile = window.innerWidth < MOBILE_BREAKPOINT;
+      setIsMobile(nowMobile);
+      if (!nowMobile) {
+        setIsSidebarVisible(true);
+      } else {
+        setIsSidebarVisible(false);
+      }
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   // ── Keyboard shortcuts ──────────────────────────────────────────────
   useEffect(() => {
@@ -131,7 +155,15 @@ export default function Layout() {
         </button>
       )}
 
-      <aside className={`sidebar ${!isSidebarVisible ? 'hidden' : ''}`}>
+      {isMobile && isSidebarVisible && (
+        <div
+          className="sidebar-backdrop"
+          onClick={() => setIsSidebarVisible(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <aside className={`sidebar ${isSidebarVisible ? 'visible' : 'hidden'}`}>
         <div className="sidebar-logo">
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,6 +59,10 @@ h1, h2, h3, h4 {
   transform: translateX(-100%);
 }
 
+.sidebar.visible {
+  transform: translateX(0);
+}
+
 .sidebar-logo {
   padding: 0 24px 32px;
   border-bottom: 1px solid rgba(245,240,232,0.1);
@@ -438,6 +442,15 @@ h1, h2, h3, h4 {
   animation: slideUp 0.25s ease;
 }
 
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(13,13,13,0.45);
+  z-index: 99;
+  opacity: 0;
+  animation: fadeIn 0.2s ease forwards;
+}
+
 .modal-header {
   display: flex;
   align-items: center;
@@ -693,12 +706,31 @@ h1, h2, h3, h4 {
 
 /* Responsive */
 @media (max-width: 768px) {
-  .sidebar { transform: translateX(-240px); }
-  .main-content { margin-left: 0; }
-  .page-header, .page-body { padding: 24px 20px; }
+  .sidebar { width: 80vw; max-width: 320px; }
+  .main-content { margin-left: 0; padding: 24px 20px; }
+  .page-header { padding: 24px 20px 18px; }
+  .page-body { padding: 18px 20px 28px; }
   .grid-2, .grid-3, .grid-4 { grid-template-columns: 1fr; }
+  .auto-grid { grid-template-columns: 1fr; }
   .auth-page { grid-template-columns: 1fr; }
   .auth-left { display: none; }
+  .sidebar-toggle-floating { top: 16px; left: 16px; }
+  .section-title { flex-direction: column; align-items: flex-start; gap: 10px; }
+  .rating-row { flex-direction: column; align-items: stretch; }
+  .rating-val { align-self: flex-start; }
+  .modal { padding: 24px; border-radius: 16px; }
+}
+
+@media (max-width: 600px) {
+  body { font-size: 14px; }
+  h1, h2, h3, h4 { line-height: 1.25; }
+  .page-header h2 { font-size: 24px; }
+  .card { padding: 18px; }
+  .card-sm { padding: 12px; }
+  .stat-card { padding: 16px 18px; }
+  .stat-card .stat-value { font-size: 28px; }
+  .btn { padding: 9px 16px; }
+  .btn-lg { padding: 12px 20px; font-size: 15px; }
 }
 
 /* Scrollbar */


### PR DESCRIPTION
# Summary
This PR improves the mobile experience across the app by making the layout responsive and the sidebar usable on small screens. It adds a mobile-safe sidebar toggle/backdrop, adjusts spacing/typography for phones, and ensures key grid layouts collapse cleanly to a single column.

# Changes

1. Make sidebar mobile-aware with backdrop and auto-hide on small screens
2. Tighten spacing, font sizes, and paddings for phone layouts
3. Ensure grids and page sections stack cleanly on small widths